### PR TITLE
Use multiclock mode in formal verification

### DIFF
--- a/hw/spinal/projectname/MyTopLevelFormal.scala
+++ b/hw/spinal/projectname/MyTopLevelFormal.scala
@@ -6,7 +6,7 @@ import spinal.core.formal._
 // You need SymbiYosys to be installed.
 // See https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Formal%20verification/index.html#installing-requirements
 object MyTopLevelFormal extends App {
-  FormalConfig
+  SpinalFormalConfig( _hasAsync = true )
     .withBMC(10)
     .doVerify(new Component {
       val dut = FormalDut(MyTopLevel())


### PR DESCRIPTION
Specify we have async signals / resets in the formal verification configuration with SpinalFormalConfig( _hasAsync = true ) .
This works for SpinalHDL 1.10.1.

With the newer SpinalHDL versions ( dev-branch )t version we could use FormalConfig.withAsync() .