### PR TITLE
Unify conf file for sbt and mill.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,11 @@
 ThisBuild / version := "1.0"
-ThisBuild / scalaVersion := "2.12.18"
 ThisBuild / organization := "org.example"
 
-val spinalVersion = "1.10.2a"
+import com.typesafe.config._
+val conf = ConfigFactory.parseFile(new File("version.conf")).resolve()
+ThisBuild / scalaVersion := conf.getString("scalaVersion")
+val spinalVersion = conf.getString("spinalVersion")
+
 val spinalCore = "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion
 val spinalLib = "com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion
 val spinalIdslPlugin = compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion)

--- a/build.sc
+++ b/build.sc
@@ -13,7 +13,8 @@ object projectname extends SbtModule {
   )
   def ivyDeps = Agg(
     ivy"com.github.spinalhdl::spinalhdl-core:$spinalVersion",
-    ivy"com.github.spinalhdl::spinalhdl-lib:$spinalVersion"
+    ivy"com.github.spinalhdl::spinalhdl-lib:$spinalVersion",
+    ivy"com.github.spinalhdl::spinalhdl-tester:$spinalVersion"
   )
   def scalacPluginIvyDeps = Agg(ivy"com.github.spinalhdl::spinalhdl-idsl-plugin:$spinalVersion")
 }

--- a/build.sc
+++ b/build.sc
@@ -1,9 +1,12 @@
 import mill._, scalalib._
 
-val spinalVersion = "1.10.2a"
+import com.typesafe.config._
+import java.io.File
+val conf = ConfigFactory.parseFile(new File("version.conf")).resolve()
+val spinalVersion = conf.getString("spinalVersion")
 
 object projectname extends SbtModule {
-  def scalaVersion = "2.12.18"
+  def scalaVersion = conf.getString("scalaVersion")
   override def millSourcePath = os.pwd
   def sources = T.sources(
     millSourcePath / "hw" / "spinal"

--- a/version.conf
+++ b/version.conf
@@ -1,0 +1,2 @@
+scalaVersion="2.12.18"
+spinalVersion="1.10.2"


### PR DESCRIPTION
Example to support both sbt and mill in one project, and specified version in unified conf file.